### PR TITLE
updated dockerfile to build from alpine source for transparency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,34 @@
-FROM ljsommer/python-base
+ARG alpine_version
+
+FROM alpine:${alpine_version}
+
+RUN apk add --no-cache --update \
+  bash \
+        build-base \
+  git \
+        libffi-dev \
+  openssh \
+        openssl-dev \
+        python3 \
+        python3-dev
+
+RUN python3 -m ensurepip && \
+  rm -r /usr/lib/python*/ensurepip && \
+  pip3 install --upgrade pip setuptools && \
+  if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip; fi && \
+  if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+  rm -r /root/.cache
+
+RUN pip3 install --upgrade pip \
+  awscli --upgrade --user \
+  boto3 \
+        cffi \
+  pyyaml
+
+RUN mkdir /root/.aws/ && chmod 0700 /root/.aws/
+RUN mkdir /root/.ssh/ && chmod 0700 /root/.ssh/
+
+ONBUILD ADD . /app/src
 
 ARG terraform_version
 RUN wget "https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_amd64.zip" -O /tmp/terraform.zip

--- a/setup/full.ps1
+++ b/setup/full.ps1
@@ -1,3 +1,4 @@
+$alpine_version    = "3.7"
 $ansible_version   = "2.5.0"
 $container_aws_dir = "/root/.aws"
 $container_name    = "terramorph"
@@ -20,6 +21,7 @@ echo "   Terraform version: $terraform_version"
 echo ""
 
 docker build -t $image_name `
+    --build-arg alpine_version=$alpine_version `
     --build-arg ansible_version=$ansible_version `
     --build-arg terraform_version=$terraform_version `
     ..

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+alpine_version="3.7"
 ansible_version="2.5.0"
 image_name="terramorph"
 terraform_version="0.11.3"
@@ -11,6 +12,7 @@ echo "   Terraform version: $terraform_version"
 echo ""
 
 docker build -t $image_name \
+    --build-arg alpine_version=$alpine_version \
     --build-arg ansible_version=$ansible_version \
     --build-arg terraform_version=$terraform_version \
     ..


### PR DESCRIPTION
Should only have to build locally once, giving the end user greater transparency to the Docker image and allowing version updates without contributor intervention.