### PR TITLE
add aws environment variables to docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,34 @@
-FROM ljsommer/python-base
+ARG alpine_version
+
+FROM alpine:${alpine_version}
+
+RUN apk add --no-cache --update \
+  bash \
+        build-base \
+  git \
+        libffi-dev \
+  openssh \
+        openssl-dev \
+        python3 \
+        python3-dev
+
+RUN python3 -m ensurepip && \
+  rm -r /usr/lib/python*/ensurepip && \
+  pip3 install --upgrade pip setuptools && \
+  if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip; fi && \
+  if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+  rm -r /root/.cache
+
+RUN pip3 install --upgrade pip \
+  awscli --upgrade --user \
+  boto3 \
+        cffi \
+  pyyaml
+
+RUN mkdir /root/.aws/ && chmod 0700 /root/.aws/
+RUN mkdir /root/.ssh/ && chmod 0700 /root/.ssh/
+
+ONBUILD ADD . /app/src
 
 ARG terraform_version
 RUN wget "https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_amd64.zip" -O /tmp/terraform.zip

--- a/setup/full.ps1
+++ b/setup/full.ps1
@@ -1,3 +1,4 @@
+$alpine_version    = "3.7"
 $ansible_version   = "2.5.0"
 $container_aws_dir = "/root/.aws"
 $container_name    = "terramorph"
@@ -20,6 +21,7 @@ echo "   Terraform version: $terraform_version"
 echo ""
 
 docker build -t $image_name `
+    --build-arg alpine_version=$alpine_version `
     --build-arg ansible_version=$ansible_version `
     --build-arg terraform_version=$terraform_version `
     ..

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -37,13 +37,18 @@ function terramorph () {
     else
         tm_argument=$1
     fi
+
+    # If AWS_* creds are set, export to ~/.aws/terramorph, to import in the container
+    if [[ -v AWS_ACCESS_KEY_ID ]] && [[ -v AWS_SECRET_ACCESS_KEY ]]; then
+      mkdir ${HOME}/.aws &>/dev/null && touch ${HOME}/.aws/terramorph &>/dev/null
+      echo export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID >> ${HOME}/.aws/terramorph
+      echo export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY >> ${HOME}/.aws/terramorph
+      if [[ -v AWS_SESSION_TOKEN ]]; then echo export AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN >> ${HOME}/.aws/terramorph; fi
+    fi 
     
     docker run -i -t --rm \
         -e "TM_LOG_LEVEL=$TM_LOG_LEVEL" \
         -e "TM_ENV=$TM_ENV" \
-        -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-        -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
-        -e "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
         -v ${HOME}/.aws/:/root/.aws/ \
         -v ${HOME}/.ssh/:/root/.ssh/ \
         -v $(pwd):/opt/terramorph/code/ \

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -40,10 +40,10 @@ function terramorph () {
 
     # If AWS_* creds are set, export to ~/.aws/terramorph, to import in the container
     if [[ -v AWS_ACCESS_KEY_ID ]] && [[ -v AWS_SECRET_ACCESS_KEY ]]; then
-      mkdir ${HOME}/.aws &>/dev/null && touch ${HOME}/.aws/terramorph &>/dev/null
-      echo export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID >> ${HOME}/.aws/terramorph
-      echo export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY >> ${HOME}/.aws/terramorph
-      if [[ -v AWS_SESSION_TOKEN ]]; then echo export AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN >> ${HOME}/.aws/terramorph; fi
+        mkdir ${HOME}/.aws &>/dev/null && touch ${HOME}/.aws/terramorph &>/dev/null
+        echo export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID >> ${HOME}/.aws/terramorph
+        echo export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY >> ${HOME}/.aws/terramorph
+        if [[ -v AWS_SESSION_TOKEN ]]; then echo export AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN >> ${HOME}/.aws/terramorph; fi
     fi 
     
     docker run -i -t --rm \

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -35,13 +35,18 @@ function terramorph () {
     else
         tm_argument=$1
     fi
+
+    # If AWS_* creds are set, export to ~/.aws/terramorph, to import in the container
+    if [[ -v AWS_ACCESS_KEY_ID ]] && [[ -v AWS_SECRET_ACCESS_KEY ]]; then
+      mkdir ${HOME}/.aws &>/dev/null && touch ${HOME}/.aws/terramorph &>/dev/null
+      echo export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID >> ${HOME}/.aws/terramorph
+      echo export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY >> ${HOME}/.aws/terramorph
+      if [[ -v AWS_SESSION_TOKEN ]]; then echo export AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN >> ${HOME}/.aws/terramorph; fi
+    fi 
     
     docker run -i -t --rm \
         -e "TM_LOG_LEVEL=$TM_LOG_LEVEL" \
         -e "TM_ENV=$TM_ENV" \
-        -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-        -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
-        -e "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
         -v ${HOME}/.aws/:/root/.aws/ \
         -v ${HOME}/.ssh/:/root/.ssh/ \
         -v $(pwd):/opt/terramorph/code/ \

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+alpine_version="3.7"
 ansible_version="2.5.0"
 image_name="terramorph"
 terraform_version="0.11.3"
@@ -11,6 +12,7 @@ echo "   Terraform version: $terraform_version"
 echo ""
 
 docker build -t $image_name \
+    --build-arg alpine_version=$alpine_version \
     --build-arg ansible_version=$ansible_version \
     --build-arg terraform_version=$terraform_version \
     ..

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -41,6 +41,9 @@ function terramorph () {
     docker run -i -t --rm \
         -e "TM_LOG_LEVEL=$TM_LOG_LEVEL" \
         -e "TM_ENV=$TM_ENV" \
+        -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+        -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+        -e "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
         -v ${HOME}/.aws/:/root/.aws/ \
         -v ${HOME}/.ssh/:/root/.ssh/ \
         -v $(pwd):/opt/terramorph/code/ \

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -39,6 +39,9 @@ function terramorph () {
     docker run -i -t --rm \
         -e "TM_LOG_LEVEL=$TM_LOG_LEVEL" \
         -e "TM_ENV=$TM_ENV" \
+        -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+        -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+        -e "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
         -v ${HOME}/.aws/:/root/.aws/ \
         -v ${HOME}/.ssh/:/root/.ssh/ \
         -v $(pwd):/opt/terramorph/code/ \

--- a/terramorph/entrypoint.sh
+++ b/terramorph/entrypoint.sh
@@ -5,6 +5,8 @@ python="/usr/bin/python"
 terramorph="/app/src/terramorph/terramorph.py"
 working_dir="/opt/terramorph/code"
 
+if [ -f /root/.aws/terramorph ]; then source /root/.aws/terramorph; rm /root/.aws/terramorph; fi
+
 echo "Docker entrypoint file: Input read as $1"
 
 cd ${working_dir}


### PR DESCRIPTION
 Use case: mfa api creds with session token

This is only for full.sh, I'm not sure how to implement it in windows.

Ran into the case where I didn't have a profile to export and needed my local creds in the docker container. Shouldn't create negative effects if environment variables are unset, allowing a profile to be used in place of env creds.