### PR TITLE
Tm profiles

### DIFF
--- a/setup/full.sh
+++ b/setup/full.sh
@@ -93,6 +93,7 @@ function terramorph () {
         -v ${HOME}/.aws/:/root/.aws/ \
         -v ${HOME}/.ssh/:/root/.ssh/ \
         -v $(pwd):/opt/terramorph/code/ \
+        -v $TM_MODULES:/opt/terramorph/modules \
         terramorph $tm_argument
 }
 

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -40,7 +40,7 @@ function terramorph () {
         echo "$TM_PROFILE"
     }
 
-    if [[ "$1" = "config" ]] || [[ ! -f ${HOME}/.terramorph/config ]] ; then
+    if [[ "$1" = "config" ]] || [[ ! -s ${HOME}/.terramorph/config ]] ; then
       export TM_PROFILE=$(config)  
       return 0 
     fi

--- a/setup/full.sh
+++ b/setup/full.sh
@@ -18,18 +18,67 @@ docker build -t $image_name \
     ..
 
 function terramorph () {
+    function config() {
+        mkdir ${HOME}/.terramorph &>/dev/null && touch ${HOME}/.terramorph/config &>/dev/null
+        read -p "Terramorph profile [default]: " TM_PROFILE
+        read -p "Terramorph environment [dev]: " TM_ENV
+        read -p "Terramorph log level [info]: " TM_LOG_LEVEL
+        read -p "Terraform modules directory [/opt/terramorph/code]: " TM_MODULES
+
+        if [[ -z "$TM_PROFILE" ]] ; then export TM_PROFILE=default; fi
+        if [[ -z "$TM_ENV" ]] ; then export TM_ENV=dev; fi
+        if [[ -z "$TM_LOG_LEVEL" ]] ; then export TM_LOG_LEVEL=info; fi
+        if [[ -z "$TM_MODULES" ]]; then export TM_MODULES=/opt/terramorph/code; fi
+    
+        sed -i "" -e '/\['"$TM_PROFILE"'\]/{N;N;N;d;}' ${HOME}/.terramorph/config &>/dev/null
+      
+        echo ["$TM_PROFILE"] >> ~/.terramorph/config
+        echo TM_ENV=$TM_ENV >> ~/.terramorph/config
+        echo TM_LOG_LEVEL=$TM_LOG_LEVEL >> ~/.terramorph/config
+        echo TM_MODULES=$TM_MODULES >> ~/.terramorph/config 
+
+        echo "$TM_PROFILE"
+    }
+
+    if [[ "$1" = "config" ]] || [[ ! -f ${HOME}/.terramorph/config ]] ; then
+      export TM_PROFILE=$(config)  
+      return 0 
+    fi
+
+    if [[ -z "${TM_PROFILE}" ]]; then read -p "Set current Terramorph profile [default]: " TM_PROFILE; fi
+
+    if [[ -z "${TM_PROFILE}" ]]; then export TM_PROFILE=default; fi
+
+    if grep -qF "[${TM_PROFILE}]" ${HOME}/.terramorph/config; then
+        export $(sed -n '/\['"${TM_PROFILE}"'\]/{n;p;n;p;n;p;}' ${HOME}/.terramorph/config)
+        printf "TM_PROFILE (profile for Terramorph exection) recognized as ${TM_PROFILE}\n"
+    else
+        echo "TM_PROFILE: ${TM_PROFILE}, is not a valid profile in ${HOME}/.terramorph/config."
+        echo "Please configure and re-run, or run 'tm config'."
+        return 1 
+    fi
+
     if [[ -z "${TM_ENV}" ]]; then
-        echo "TM_ENV environment variable not set. Please set and re-run."
+        echo "TM_ENV environment variable not set. Please set and re-run, or run 'tm config'."
         return 1
     else
         printf "TM_ENV (environment for Terramorph execution) recognized as ${TM_ENV}\n"
     fi
 
     if [[ -z "${TM_LOG_LEVEL}" ]]; then
+        export TM_LOG_LEVEL=info 
         echo "TM_LOG_LEVEL environment variable not set. Using default 'info'."
-        return 1
     else
         printf "TM_LOG_LEVEL (log level output for Terramorph) recognized as ${TM_LOG_LEVEL}\n\n"
+    fi
+
+    if [[ -z "${TM_MODULES}" ]]; then
+        echo "TM_MODULES environment variable not set. Please set and re-run, or run 'tm config'."
+    elif [[ ! -d "${TM_MODULES}" ]]; then
+        echo "TM_MODULES environment variable value: ${TM_MODULES} is not a directory."
+        echo "Please set and re-run, or run 'tm config'."
+    else
+        printf "TM_MODULES (Module environment for Terramorph execution) recognized as ${TM_MODULES}\n\n"
     fi
 
     if [ $# -eq 0 ] ; then


### PR DESCRIPTION
Added profile functionality for linux/mac.

Terramorph prompts for environment variables and then exports to ~/.terramorph/config

In the case that the ~/.terramorph/config file exists and is not empty, tm will prompt for a profile name.

All prompts handle empty responses, defaulting to the value in the brackets.

*Additionally added modules mounting. this is in the case that your code is not in /opt/terramorph/code and ends up treating /opt/terramorph/code as the working directory, with a relative path to modules in ../modules/<modules> (or /opt/terramorph/modules).